### PR TITLE
use `stringOf` instead of `oneOfString`

### DIFF
--- a/mockend.yml
+++ b/mockend.yml
@@ -6,7 +6,7 @@ models:
       cover: { imageURL: [1920, 1080] }
       title: { loremWords: [5, 20] }
       body: { loremParagraphs: [10, 100] }
-      category: { oneOfString: [one, two, three] }
+      category: { stringOf: [one, two, three] }
       isDraft: { bool: 20 }
       views: { int: [0, 1000] }
       createdAt: { dateTime: [2010-01-01T00:00:00Z, 2020-12-31T23:59:59Z] }


### PR DESCRIPTION
The current category field in the API demo shows `"category": "unknown generator"`. This fixes that to use the latest API.